### PR TITLE
add `meta[name=charset]`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Make This In An Hour</title>
     <link rel="stylesheet"
     href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
@@ -43,6 +44,7 @@
 &lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
+  &lt;meta charset=&quot;utf-8&quot;&gt;
   &lt;title&gt;YOUR SITE TITLE&lt;/title&gt;
   &lt;-- Add some style to your site, see http://getbootstrap.com for details --&gt;
   &lt;link rel=&quot;stylesheet&quot;


### PR DESCRIPTION
it's [good practice](http://www.w3.org/International/questions/qa-html-encoding-declarations#answer) to include it. it isn't actually required here in the case of GitHub Pages (since GitHub serves HTML documents with a UTF-8 charset: `Content-Type: text/html; charset=utf-8`).
